### PR TITLE
Removal of master-slave vocabulary

### DIFF
--- a/TSnosql.py
+++ b/TSnosql.py
@@ -48,8 +48,8 @@ if __name__ == '__main__':
                         help="home directory for the Twisted services [default: %default]")
     parser.add_option("-n","--nosql",dest="redis",metavar="ip",
                         help="IP address and port of service [default: %default]")
-    parser.add_option("-m","--master", dest="master",action="store_true",
-                        help="indicates running as Master instead of Slave [default: %default]")
+    parser.add_option("-m","--main", dest="main",action="store_true",
+                        help="indicates running as Main instead of Subordinate [default: %default]")
     parser.add_option("-i","--initfile",dest="initfile",metavar="file",
                         help="init file [default: %default]")
     parser.add_option("-r","--rdump",dest="dbfile",metavar="file",
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     parser.set_defaults(redis="localhost:6379")
     parser.set_defaults(debug=False)
     parser.set_defaults(homedir=".")
-    parser.set_defaults(master=False)
+    parser.set_defaults(main=False)
     (options, args) = parser.parse_args()
 
     # Logging, if necessary and make it look nice.
@@ -86,7 +86,7 @@ if __name__ == '__main__':
             server.updateCount = uc
 
     # Create the caching server
-    mserver = server(ip=options.redis,master=options.master,initfile=options.initfile,dbfile=options.dbfile)
+    mserver = server(ip=options.redis,main=options.main,initfile=options.initfile,dbfile=options.dbfile)
     mserver.ourIP = ourIP
 
     # Setup stuff for invoking log setup. We do this because if the TSnosql server fails we want
@@ -105,10 +105,10 @@ if __name__ == '__main__':
         dc.HostName = socket.gethostname()
     #log.setupLogging(dc)
 
-    logging.info("Twisted Storage nosql server started as %s on node %s." % ("master" if options.master else "slave", dc.HostName))
+    logging.info("Twisted Storage nosql server started as %s on node %s." % ("main" if options.main else "subordinate", dc.HostName))
     mserver.start()
 
-    # When we get here things are shutting down. We need to make sure the slaveDriver is all done before
+    # When we get here things are shutting down. We need to make sure the subordinateDriver is all done before
     # we exit. We don't worry about the timer task since we will get here if the server closed by itself
     # or because of the timer going off. 
     logging.info("Twisted Storage nosql server terminating.")

--- a/lib/nosql.py
+++ b/lib/nosql.py
@@ -50,9 +50,9 @@ class nosql(object):
         In addition to the variables, TSnosql has a few other features.
         First, is the ability of the server to back up the contents of
         database to disk and recover them on restart. Secondly, this
-        initial release supports slave servers, all interlinked. This
-        means an update to the master will ripple through to all the
-        slaves. Finally, the "database" isn't just one big database: it
+        initial release supports subordinate servers, all interlinked. This
+        means an update to the main will ripple through to all the
+        subordinates. Finally, the "database" isn't just one big database: it
         is composed of many individual, and separately addressible
         databases. So you have the ability to store variables in
         any particular sub-database.
@@ -62,7 +62,7 @@ class nosql(object):
         better (it hasn't been tested on Python 3.0 yet).
 
         Future releases of TSnosql will include support for multi-
-        master mode as well as some extensions to the command set.
+        main mode as well as some extensions to the command set.
 
         There are four types of commands in the system:
 
@@ -96,7 +96,7 @@ class nosql(object):
                 - connect to the server
                 - disconnect from a server
                 - ping a server to see if it is alive
-                - connect a server (master or slave) to another slave
+                - connect a server (main or subordinate) to another subordinate
                 - return the version of the server
                 - return information about a server
                 - does a variable exist?
@@ -246,9 +246,9 @@ class nosql(object):
             self.lock.release()
         return rc
 
-    def slave(self,host,port):
+    def subordinate(self,host,port):
         """
-            Connect a slave server to this server.\r\n
+            Connect a subordinate server to this server.\r\n
             Protocol::
 
                     Client to server:   SLAVE <host> <port>\\r\\n
@@ -258,10 +258,10 @@ class nosql(object):
                                         -ERR <error message>\\r\\n
 
             @type host: string
-            @param host: FQDN or IP address of slave server
+            @param host: FQDN or IP address of subordinate server
 
             @type port: integer
-            @param port: port nunmber of slave server
+            @param port: port nunmber of subordinate server
 
             @rtype: string
             @return: OK if it worked

--- a/redis/TScomm.py
+++ b/redis/TScomm.py
@@ -15,13 +15,13 @@ import socket
 
 from TSexcept import ConnectionError, InvalidResponse, ResponseError
 
-# Class to handle restricted communication with a slave server.
+# Class to handle restricted communication with a subordinate server.
 #
 # This class contains only the functions necessary to communicate 
-# with a slave. This includes __init__(), ping(), write(), get_response(),
+# with a subordinate. This includes __init__(), ping(), write(), get_response(),
 # connect() and disconnect().
 #
-class SlaveComm:
+class SubordinateComm:
     def __init__(self, host=None, port=None, timeout=None):
         self.host = host or 'localhost'
         self.port = port or 6400

--- a/redis/nosql.py
+++ b/redis/nosql.py
@@ -68,9 +68,9 @@ class nosql(object):
         In addition to the variables, TSnosql has a few other features.
         First, is the ability of the server to back up the contents of
         database to disk and recover them on restart. Secondly, this
-        initial release supports slave servers, all interlinked. This
-        means an update to the master will ripple through to all the
-        slaves. Finally, the "database" isn't just one big database: it
+        initial release supports subordinate servers, all interlinked. This
+        means an update to the main will ripple through to all the
+        subordinates. Finally, the "database" isn't just one big database: it
         is composed of many individual, and separately addressible
         databases. So you have the ability to store variables in
         any particular sub-database.
@@ -80,7 +80,7 @@ class nosql(object):
         better (it hasn't been tested on Python 3.0 yet).
 
         Future releases of TSnosql will include support for multi-
-        master mode as well as some extensions to the command set.
+        main mode as well as some extensions to the command set.
 
         There are four types of commands in the system:
 
@@ -114,7 +114,7 @@ class nosql(object):
                 - connect to the server
                 - disconnect from a server
                 - ping a server to see if it is alive
-                - connect a server (master or slave) to another slave
+                - connect a server (main or subordinate) to another subordinate
                 - return the version of the server
                 - return information about a server
                 - does a variable exist?
@@ -276,9 +276,9 @@ class nosql(object):
             self.lock.release()
         return rc
 
-    def slave(self,host,port):
+    def subordinate(self,host,port):
         """
-            Connect a slave server to this server.\r\n
+            Connect a subordinate server to this server.\r\n
             Protocol::
 
                     Client to server:   SLAVE <host> <port>\\r\\n
@@ -288,10 +288,10 @@ class nosql(object):
                                         -ERR <error message>\\r\\n
 
             @type host: string
-            @param host: FQDN or IP address of slave server
+            @param host: FQDN or IP address of subordinate server
 
             @type port: integer
-            @param port: port nunmber of slave server
+            @param port: port nunmber of subordinate server
 
             @rtype: string
             @return: OK if it worked


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.